### PR TITLE
feat: add default repo and improve error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## 配置
 
-在 `_conf_schema.json` 中设置 `token` 和 `repo`，用于访问 CNB API。
+在 `_conf_schema.json` 中设置 `token`，以及可选的 `repo`（未设置时默认为 `cnb/docs`），用于访问 CNB API。
 
 ## 使用
 

--- a/main.py
+++ b/main.py
@@ -8,7 +8,9 @@ class CnbPlugin(Star):
     def __init__(self, context: Context):
         super().__init__(context)
         self.token = self.context.get("token") if hasattr(self.context, "get") else None
-        self.repo = self.context.get("repo") if hasattr(self.context, "get") else None
+        self.repo = (
+            self.context.get("repo") if hasattr(self.context, "get") else None
+        ) or "cnb/docs"
 
     async def initialize(self):
         """插件初始化"""
@@ -21,8 +23,11 @@ class CnbPlugin(Star):
             yield event.plain_result("请在指令后提供问题，例如 `/cnb 你的问题`")
             return
 
-        if not self.token or not self.repo:
-            yield event.plain_result("插件未配置 token 或 repo")
+        if not self.token:
+            yield event.plain_result("插件未配置 token")
+            return
+        if not self.repo:
+            yield event.plain_result("插件未配置 repo")
             return
 
         try:


### PR DESCRIPTION
## Summary
- default to `cnb/docs` when repo is not configured
- separate missing token and repo errors
- document default repo in README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_688ee013c0a48327a345d23b99672cf8