### PR TITLE
feat: support custom knowledge base repo with platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@
 
 ## 使用
 
-发送 `/cnb 你的问题` 即可使用默认知识库得到回答；若需查询其他知识库，使用 `/cnb user/repo 你的问题`。
+发送 `/cnb 你的问题` 即可使用默认知识库得到回答；若需查询其他知识库，使用 `/cnb user/repo 你的问题`。若知识库位于其他平台，可使用 `/cnb user/platform/repo 你的问题` 指定平台，例如 `/cnb valetzx/github/HowToCook 如何做蛋糕`。

--- a/main.py
+++ b/main.py
@@ -30,15 +30,22 @@ class CnbPlugin(Star):
             yield event.plain_result("请在指令后提供问题，例如 `/cnb 你的问题`")
             return
 
-        # 允许用户在指令中指定知识库，例如 `/cnb user/repo 你的问题`
+        # 允许用户在指令中指定知识库，例如
+        # `/cnb user/repo 你的问题` 或 `/cnb user/provider/repo 你的问题`
         parts = message.split(maxsplit=1)
         repo = self.repo
         if "/" in parts[0]:
-            repo = parts[0]
+            repo_candidate = parts[0]
             if len(parts) < 2 or not parts[1].strip():
                 yield event.plain_result("请在指令后提供问题，例如 `/cnb 知识库 你的问题`")
                 return
             question = parts[1].strip()
+            segments = repo_candidate.split("/")
+            if len(segments) == 3:
+                # 支持 `user/provider/repo` 格式，将其转换为 `provider/user/repo`
+                repo = f"{segments[1]}/{segments[0]}/{segments[2]}"
+            else:
+                repo = repo_candidate
         else:
             question = message
 


### PR DESCRIPTION
## Summary
- allow specifying repository in `user/platform/repo` format and convert to `platform/user/repo` for API calls
- document platform-aware knowledge base usage

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_688efe9f42f083279fb72135081c180a