### PR TITLE
Allow repo override via command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # chat-cnb
 
-基于 CNB 知识库的 AstrBot 插件。用户发送 `/cnb 问题` 指令或在指令中指定知识库 `/cnb user/repo 问题` 后，插件会：
+基于 CNB 知识库的 AstrBot 插件。用户发送 `/cnb 问题` 指令或在指令中指定知识库（例如 `/cnb user/repo 问题` 或 `/cnb repo:user/repo 问题`）后，插件会：
 
 1. 调用 CNB 知识库查询接口获取相关内容；
 2. 构造 RAG 提示词并调用 AI 对话接口生成回答；
@@ -12,4 +12,4 @@
 
 ## 使用
 
-发送 `/cnb 你的问题` 即可使用默认知识库得到回答；若需查询其他知识库，使用 `/cnb user/repo 你的问题`。
+发送 `/cnb 你的问题` 即可使用默认知识库得到回答；若需查询其他知识库，使用 `/cnb user/repo 你的问题` 或 `/cnb repo:user/repo 你的问题`。

--- a/main.py
+++ b/main.py
@@ -30,17 +30,23 @@ class CnbPlugin(Star):
             yield event.plain_result("请在指令后提供问题，例如 `/cnb 你的问题`")
             return
 
-        # 允许用户在指令中指定知识库，例如 `/cnb user/repo 你的问题`
+        # 允许用户在指令中指定知识库，例如
+        # `/cnb user/repo 你的问题` 或 `/cnb repo:user/repo 你的问题`
         parts = message.split(maxsplit=1)
         repo = self.repo
-        if "/" in parts[0]:
-            repo = parts[0]
-            if len(parts) < 2 or not parts[1].strip():
-                yield event.plain_result("请在指令后提供问题，例如 `/cnb 知识库 你的问题`")
-                return
-            question = parts[1].strip()
-        else:
-            question = message
+        question = message
+        if parts:
+            first = parts[0]
+            if first.startswith("repo:"):
+                repo = first[5:]
+                question = parts[1].strip() if len(parts) > 1 else ""
+            elif "/" in first and not first.startswith("http://") and not first.startswith("https://"):
+                repo = first
+                question = parts[1].strip() if len(parts) > 1 else ""
+
+        if not question:
+            yield event.plain_result("请在指令后提供问题，例如 `/cnb [知识库] 你的问题`")
+            return
 
         if not self.token:
             yield event.plain_result("插件未配置 token")


### PR DESCRIPTION
## Summary
- allow `/cnb` command to override the knowledge base by prefixing `user/repo` or `repo:user/repo`
- document repo override usage in README

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_b_688efe9f42f083279fb72135081c180a