### PR TITLE
feat: add think mode toggle

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -12,5 +12,11 @@
         "hint": "repo123",
         "default": " ",
         "obvious_hint": false
+    },
+    "think": {
+        "description": "思考模式",
+        "type": "bool",
+        "hint": "展示思考内容",
+        "default": false
     }
 }


### PR DESCRIPTION
## Summary
- add `think` configuration to expose model reasoning
- support `/cnb think on|off` to control think output
- wrap responses with `<think>` and `<answer>` tags based on configuration

## Testing
- `python -m py_compile main.py && python -m json.tool _conf_schema.json`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688f0a26a4888327ad1daeec9962bd2d